### PR TITLE
Fixed errors caused by spaces in filenames, fixed errors on MacOS and a few other minor changes

### DIFF
--- a/theta_rectify.sh
+++ b/theta_rectify.sh
@@ -8,14 +8,14 @@
 # Print usage
 HELP="Usage: theta_rectify.sh [-f] FILE [FILE ...]
   Automatically levels Ricoh Theta spherical images"
-if [ $# == 0 ] || [ $1 = "--help" ] ; then
+if [ "${#}" == 0 ] || [ "$1" = "--help" ] ; then
     echo "$HELP"
     exit 1;
 fi
 
 # check if the user requested us to overwrite previously processed images
 FORCE=0
-if [ $1 = "-f" ]; then
+if [ "$1" = "-f" ]; then
   FORCE=1
   echo "-f passed; will clobber extant files."
   shift
@@ -24,7 +24,7 @@ fi
 # Process each file passed on the command line
 while [ ${#} -gt 0 ]
 do
-  if [ ! -e $1 ]; then
+  if [ ! -e "$1" ]; then
     echo "File $1 not found."
     exit 2
   fi
@@ -38,7 +38,7 @@ do
   # calculate destination name and check for existence before proceeding
   destfile="${noextension}_rectified.jpg"
 
-  if [ -e $destfile -a $FORCE -ne 1 ]; then
+  if [ -e "$destfile" -a $FORCE -ne 1 ]; then
     echo "Converted file ${destfile} already exists. Skipping. Use -f to force."
     shift
     continue

--- a/theta_rectify.sh
+++ b/theta_rectify.sh
@@ -5,6 +5,10 @@
 # Should work on most Linux installs and on
 # OSX using homebrew installs or similar
 
+# change the internal field separator to allow spaces in filenames
+SAVEIFS=$IFS 
+IFS=$(echo -en "\n\b")
+
 FORCE=0
 if [ $1 = "-f" ]; then
   FORCE=1
@@ -67,22 +71,22 @@ camera {
 // create a sphere shape
 sphere {
   // center of sphere
-  <0,0,0>, 1       
+  <0,0,0>, 1
   texture {
     pigment {
       image_map {
         jpeg "$TMP_ROOT.jpg"
         interpolate 2 // smooth it
-        once   // don't tile image, just one copy  
+        once   // don't tile image, just one copy
         map_type 1
-      }     
+      }
     }
     rotate x * $roll   //Tilt up (+) or down (-) or PITCH
     rotate y * 0       //shift left (+) or right (-)
     rotate z * $pitch  //Rotate CCW (+) or CW (-) or ROLL
-    finish { ambient 1 }      
+    finish { ambient 1 }
   }
-}                                   
+}
 EOF
 
   # execute povray script and rename file
@@ -94,6 +98,9 @@ EOF
   rm $TMP_ROOT.pov
 
   # copy original metadata to dest, removing the corrections that have just been made
-  exiftool -overwrite_original -TagsFromFile "$1" -PosePitchDegrees= -PoseRollDegrees= "$destfile" 
+  exiftool -overwrite_original -TagsFromFile "$1" -PosePitchDegrees= -PoseRollDegrees= "$destfile"
   shift
 done
+
+# Restore default shell IFS
+IFS=$SAVEIFS

--- a/theta_rectify.sh
+++ b/theta_rectify.sh
@@ -1,10 +1,19 @@
 #!/bin/bash
 #
-# Automatically levels Theta S spherical images
+# Automatically levels Ricoh Theta spherical images
 # depends on exiftools / imagemagick and POVRay
 # Should work on most Linux installs and on
 # OSX using homebrew installs or similar
 
+# Print usage
+HELP="Usage: theta_rectify.sh [-f] FILE [FILE ...]
+  Automatically levels Ricoh Theta spherical images"
+if [ $# == 0 ] || [ $1 = "--help" ] ; then
+    echo "$HELP"
+    exit 1;
+fi
+
+# check if the user requested us to overwrite previously processed images
 FORCE=0
 if [ $1 = "-f" ]; then
   FORCE=1
@@ -12,6 +21,7 @@ if [ $1 = "-f" ]; then
   shift
 fi
 
+# Process each file passed on the command line
 while [ ${#} -gt 0 ]
 do
   if [ ! -e $1 ]; then
@@ -22,7 +32,7 @@ do
   # get the filename without the extension
   noextension=`echo "$1" | sed 's/\(.*\)\..*/\1/'`
 
-  # generate a temp name so that parallel runs dont clobber each other
+  # generate a temp name so that parallel runs don't clobber each other
   TMP_ROOT="${RANDOM}_theta_rectify.tmp"
 
   # calculate destination name and check for existence before proceeding
@@ -37,7 +47,7 @@ do
   # extract metadata from image
   EXIF=$(exiftool "$1")
 
-  # grab the width and height of the images
+  # grab the width and height of the images from previously extracted metadata
   height=`echo "$EXIF" | grep "^Image Height" | cut -d':' -f2 | sed 's/ //g' | head -n1`
   width=`echo "$EXIF" | grep "^Image Width" | cut -d':' -f2 | sed 's/ //g' | head -n1`
 
@@ -87,7 +97,7 @@ sphere {
 }
 EOF
 
-  # execute povray script and rename file
+  # execute povray script, save output to temporary file and rename it
   TMP_DEST=${TMP_ROOT}_rectified.jpg
   povray +W$width +H$height -D +fj $TMP_ROOT.pov "+O$TMP_DEST"
   mv "$TMP_DEST" "$destfile"


### PR DESCRIPTION
- Added a fix for errors when processing file with spaces in names
- Added a fix for "theta_rectify.sh: line 9: [: too many arguments" error on MacOS
- Change: decreased exiftool calls, for a little better performance
- Added help and extended comments
- Removed a duplicate variable declaration
